### PR TITLE
Update 20250224

### DIFF
--- a/src/gateways/InMemoryMessageGateway.ts
+++ b/src/gateways/InMemoryMessageGateway.ts
@@ -14,6 +14,7 @@ import {
   GetMessagesByRoomIdProps,
   GetMessagesRecursiveByHumanProps,
 } from "../ports/MessageGatewayPort";
+import { saveMessages } from "../utils/FileSystemUtils";
 
 const messages: Message[] = [];
 let newMessageId = 0;
@@ -183,7 +184,9 @@ export class InMemoryMessageGateway implements MessageGatewayPort {
       parentMessageId: p.parentMessageId,
     };
     messages.push(newMessage);
-    console.log("push messages", messages);
+    // console.log("push messages", messages);
+    console.log("新しいメッセージを追加: ", newMessage);
+    // saveMessages(messages);
     newMessageId++;
     return Promise.resolve(newMessage);
   }

--- a/src/gateways/InMemoryMessageGeneratorGateway.ts
+++ b/src/gateways/InMemoryMessageGeneratorGateway.ts
@@ -126,16 +126,16 @@ const createAiPromptWithHuman = (
   targetUserName: string,
   selfUserName: string
 ) => {
-  return `あなたは${selfUserName}です。あなたは${targetUserName}さんと人間と会話をしています。
+  return `あなたは${selfUserName}です。あなた(${selfUserName})は${targetUserName}さんと人間と会話をしています。
 ${messages.map((msg) => `${msg.userName}の発言「${msg.content}」`).join("\n")}
-この後にあなたが人間に対して返答してください。
+この後にあなた(${selfUserName})が人間に対して返答してください。
 
 以下の5パターンのうち合致する条件で返答してください。
-・もし人間があなたの立場に近い場合、人間の意見に同調してください。
+・もし人間があなた(${selfUserName})の立場に近い場合、人間の意見に同調してください。
 ・もし人間が${targetUserName}さんの立場に近い場合、人間に反論してください。
 ・もし人間の発言が関係ない話題の場合、その内容に言及した上で反論してください。
 ・もし人間の発言が不適切な場合、その旨を伝えた上で反論してください。
-・もし人間の発言があなたへの質問である場合、その質問に答えてください。
+・もし人間の発言があなた(${selfUserName})への質問である場合、その質問に答えてください。
 
 その際に以下のルールを守ってください。
 ・160文字程度で書いてください。
@@ -154,10 +154,9 @@ const createAiPrompt = (
   content: string,
   selfUserName: string
 ) => {
-  return `
-あなたは${targetUserName}さんと会話をしています。
+  return `あなたは${selfUserName}です。あなた(${selfUserName})は${targetUserName}さんと会話をしています。
 ${targetUserName}さん「${content}」
-この後にあなたが反論します。
+この後にあなた(${selfUserName})が反論します。
 
 その際に以下のルールを守ってください。
 ・160文字程度で書いてください。
@@ -171,7 +170,7 @@ ${targetUserName}さん「${content}」
 必ず以下のJSONフォーマットでtargetとcontentという変数名を変えずに返答ください。
 {
   "target": "${targetUserName}",
-  "content": "{あなたの反論}"
+  "content": "{あなた(${selfUserName})の反論}"
 }
 `;
 };

--- a/src/ports/MessageGeneratorGatewayPort.ts
+++ b/src/ports/MessageGeneratorGatewayPort.ts
@@ -4,7 +4,8 @@ import { User } from "../entities/User";
 
 type MessageInfo = {
   aiMessageContent: string; // メッセージの本文
-  userName: User["name"];
+  targetUserName: User["name"];
+  selfUserName: User["name"];
   gptSystem: User["originalGptSystem"] | ChatRoomMember["gptSystem"];
 };
 

--- a/src/ports/MessageGeneratorGatewayPort.ts
+++ b/src/ports/MessageGeneratorGatewayPort.ts
@@ -3,19 +3,13 @@ import { Message } from "../entities/Message";
 import { User } from "../entities/User";
 
 type MessageInfo = {
-  aiMessageContent: string; // メッセージの本文
-  targetUserName: User["name"];
-  selfUserName: User["name"];
-  gptSystem: User["originalGptSystem"] | ChatRoomMember["gptSystem"];
-};
-
-type MessageInfoWithHuman = {
   messages: {
     content: string;
     userName: User["name"];
   }[];
   targetUserName: User["name"];
   selfUserName: User["name"];
+  humanName: User["name"];
   gptSystem: User["originalGptSystem"] | ChatRoomMember["gptSystem"];
 };
 
@@ -32,12 +26,6 @@ export type GenerateProps = {
   model: string;
 };
 
-export type GenerateWithHumanProps = {
-  info: MessageInfoWithHuman;
-  apiKey: string;
-  model: string;
-};
-
 export type GenerateResponse = {
   target: string;
   content: string;
@@ -49,5 +37,5 @@ export interface MessageGeneratorGatewayPort {
   // ChatGPTに次のメッセージの生成を要求
   generate(p: GenerateProps): Promise<GenerateResponse>;
   // ChatGPTに次のメッセージの生成を要求(人のメッセージも加味する)
-  generateWithHuman(p: GenerateWithHumanProps): Promise<GenerateResponse>;
+  generateWithHuman(p: GenerateProps): Promise<GenerateResponse>;
 }

--- a/src/usecases/ChatUseCase.ts
+++ b/src/usecases/ChatUseCase.ts
@@ -21,7 +21,14 @@ export type InitializeChatResponse = {
   room: ChatRoom;
   members: (ChatRoomMember & Pick<User, "name">)[];
 };
-
+/**
+ * チャットルームの初期化
+ * チャットルームを作成し、チャットメンバーを追加する
+ * @param p 初期化するチャットルームの情報
+ * @param userGateway ユーザーゲートウェイ
+ * @param chatRoomGateway チャットルームゲートウェイ
+ * @returns 初期化したチャットルームの情報
+ */
 export const initializeChat = async (
   p: InitializeChatProps,
   userGateway: UserGatewayPort,

--- a/src/utils/FileSystemUtils.ts
+++ b/src/utils/FileSystemUtils.ts
@@ -1,0 +1,10 @@
+import fs from "fs/promises";
+import path from "path";
+import { Message } from "../entities/Message";
+
+const STORAGE_FILE = path.join(process.cwd(), "data", "messages.json");
+
+export const saveMessages = async (messages: Message[]) => {
+  await fs.mkdir(path.dirname(STORAGE_FILE), { recursive: true });
+  await fs.writeFile(STORAGE_FILE, JSON.stringify(messages, null, 2), "utf-8");
+};


### PR DESCRIPTION
- 普段の会話も最新10件の会話を入れて生成する
- 人間のpromptを調整
- 会話の流れをより保つために要約を生成する際に要約に含めるメッセージを3件から10件にする
- 要約を5000文字から10000文字にする
- 人間の発言を加味するときにAIの名前を渡せていなかったので修正
- 人間を加味しない場合のメッセージの生成にAIの名前を入れるようにする